### PR TITLE
adventure-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,21 @@ _Remember_ that you need to unlock your compendia to be able to add things to th
 
 ## Default Setup
 
-This module comes with 12 Default compendia:
+This module comes with 13 Default compendia:
 
-- `Actors (shared)` ([Actor](https://foundryvtt.com/api/Actor.html))
-- `Classes (shared)` ([Item](https://foundryvtt.com/api/Item.html))
-- `Feats (shared)` ([Item](https://foundryvtt.com/api/Item.html))
-- `Items (shared)` ([Item](https://foundryvtt.com/api/Item.html))
-- `Journal Entries (shared)` ([JournalEntry](https://foundryvtt.com/api/JournalEntry.html))
-- `Macros (shared)` ([Macro](https://foundryvtt.com/api/Macro.html))
-- `Monsters (shared)` ([Actor](https://foundryvtt.com/api/Actor.html))
-- `Playlists (shared)` ([Playlist](https://foundryvtt.com/api/Playlist.html))
-- `Roll Tables (shared)` ([RollTable](https://foundryvtt.com/api/RollTable.html))
-- `Scenes (shared)` ([Scene](https://foundryvtt.com/api/Scene.html))
-- `Spells (shared)` ([Item](https://foundryvtt.com/api/Item.html))
-- `Subclasses (shared)` ([Item](https://foundryvtt.com/api/Item.html))
+- `Actors (shared)` ([Actor](https://foundryvtt.com/article/actors/))
+- `Adventures (shared)` (Adventures - documentation pending)
+- `Classes (shared)` ([Item](https://foundryvtt.com/article/items/))
+- `Feats (shared)` ([Item](https://foundryvtt.com/article/items/))
+- `Items (shared)` ([Item](https://foundryvtt.com/article/items/))
+- `Journal Entries (shared)` ([JournalEntry](https://foundryvtt.com/article/journal/))
+- `Macros (shared)` ([Macro](https://foundryvtt.com/article/macros/))
+- `Monsters (shared)` ([Actor](https://foundryvtt.com/article/actors/))
+- `Playlists (shared)` ([Playlist](https://foundryvtt.com/article/playlists/))
+- `Roll Tables (shared)` ([RollTable](https://foundryvtt.com/article/roll-tables/))
+- `Scenes (shared)` ([Scene](https://foundryvtt.com/article/scenes/))
+- `Spells (shared)` ([Item](https://foundryvtt.com/article/items/))
+- `Subclasses (shared)` ([Item](https://foundryvtt.com/article/items/))
 
 ## Customize
 

--- a/module.json
+++ b/module.json
@@ -10,12 +10,20 @@
       "name": "Napoleone Piani"
     }
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "compatibility": {
-    "minimum": "9",
+    "minimum": "10",
     "verified": "10"
   },
   "packs": [
+    {
+      "name": "adventures",
+      "system": "dnd5e",
+      "label": "Adventures (shared)",
+      "path": "./packs/adventures.db",
+      "module": "my-shared-compendia",
+      "type": "Adventure"
+    },
     {
       "name": "actors",
       "system": "dnd5e",
@@ -113,7 +121,7 @@
       "type": "Playlist"
     }
   ],
-  "download": "https://github.com/stschoelzel/My-Shared-Compendia/archive/v1.2.0.zip",
+  "download": "https://github.com/stschoelzel/My-Shared-Compendia/archive/v1.3.0.zip",
   "manifest": "https://github.com/stschoelzel/My-Shared-Compendia/releases/latest/download/module.json",
   "url": "https://github.com/stschoelzel/My-Shared-Compendia"
 }


### PR DESCRIPTION
- Adventure compendium added
- Updated broken api links to article links (which then contain api links if needed)
- Removed v9 compatibility. Failed to install module on fresh v9 install. I believe the 1.2 v10 module.json changes caused this to fail.)
![image](https://user-images.githubusercontent.com/22131782/195882325-ec3051d6-2c49-46a8-b1b1-6151ab903d26.png)
